### PR TITLE
Add x86_64-linux platform to Gemfile.lock

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -117,6 +117,8 @@ GEM
     nio4r (2.5.9)
     nokogiri (1.15.4-x86_64-darwin)
       racc (~> 1.4)
+    nokogiri (1.15.4-x86_64-linux)
+      racc (~> 1.4)
     pg (1.5.4)
     psych (5.1.0)
       stringio
@@ -189,6 +191,7 @@ GEM
 
 PLATFORMS
   x86_64-darwin-21
+  x86_64-linux
 
 DEPENDENCIES
   bootsnap


### PR DESCRIPTION
ソースコードをHerokuにpushしたら、"Your bundle only supports platforms ["x86_64-darwin-21"] but your local platform is x86_64-linux."というエラーが発生したので、メッセージ通りに`bundle lock --add-platform x86_64-linux` を実行。